### PR TITLE
Url Slug Hardening

### DIFF
--- a/functions/functions.js
+++ b/functions/functions.js
@@ -10,5 +10,23 @@ export function parseDate(date) {
 }
 
 export function slugify(title) {
-  return title.split(' ').join('-')
+  return (
+    title
+      //Remove leading and trailing whitespace
+      .trim()
+      //Make all alpha characters lowercase
+      .toLowerCase()
+      //Replace spaces with hyphens (will duplicate hypens but will be removed later)
+      .replace(/\s+/g, '-')
+      //Replace anything that is not a word or hyphen with empty string
+      .replace(/[^\w\-]+/g, '')
+      //Replace multiple hyphens with one
+      .replace(/\-\-+/g, '-')
+      //Remove hyphens from begining of string
+      .replace(/^-+/, '')
+      //Remove hyphens from end of string
+      .replace(/-+$/, '')
+      //Remove all underscores
+      .replace(/_/g, '')
+  )
 }


### PR DESCRIPTION
Use Regex to make sure slug only contains lower cased alphanumeric characters and hyphens.

This regex also keeps numbers intact so you don't end up with something like "learning-part-1-2"
Instead you get "learning-part-12"